### PR TITLE
fixed #1491: filter IN pushdown to different decoders

### DIFF
--- a/deps/oblib/src/lib/container/ob_bitmap.h
+++ b/deps/oblib/src/lib/container/ob_bitmap.h
@@ -71,6 +71,12 @@ public:
   OB_INLINE int set(const size_type pos, const bool value = true);
 
   /**
+   * set n bits at %pos if value true
+   * or wipe out bits at %pos if value false
+   */
+  OB_INLINE int set_n(const size_type pos, const size_type n, const bool value = true);
+
+  /**
    * same as set(pos, false);
    */
   OB_INLINE int wipe(const size_type pos);
@@ -380,6 +386,74 @@ OB_INLINE int ObBitmap::set(const size_type pos, const bool value)
       cur_mem_block->bits_[inner_pos >> BLOCK_MOD_BITS] |= (1ULL << (inner_pos & BLOCK_MOD_MASK));
     } else {
       cur_mem_block->bits_[inner_pos >> BLOCK_MOD_BITS] &= (~(1ULL << (inner_pos & BLOCK_MOD_MASK)));
+    }
+  }
+  return ret;
+}
+
+OB_INLINE int ObBitmap::set_n(const size_type pos, const size_type n, const bool value) {
+  int ret = OB_SUCCESS;
+  if (OB_UNLIKELY(pos + n > valid_bits_)) {
+    ret = OB_ERROR_OUT_OF_RANGE;
+    LIB_LOG(WARN, "Pos out of valid bits", K(ret), K(pos), K(n), K(valid_bits_));
+  } else if (OB_UNLIKELY(BITS_PER_BLOCK != 64)) {
+    LIB_LOG(WARN, "BITS_PER_BLOCK not euqal to 64, do retro single set", K(ret), K(BITS_PER_BLOCK));
+    for (int64_t idx = pos; OB_SUCC(ret) && idx < pos + n; ++idx) {
+      if (OB_FAIL(set(idx))) {
+        LIB_LOG(WARN, "Failed to set result_bitmap", K(ret), K(pos), K(pos + n), K(idx));
+      }
+    }
+  } else {
+    size_type inner_pos = pos;
+    MemBlock *cur_mem_block = header_;
+    while (MEM_BLOCK_BITS <= inner_pos) {
+      cur_mem_block = cur_mem_block->next_;
+      inner_pos -= MEM_BLOCK_BITS;
+    }
+    // block index in current mem block
+    size_type block_idx = block_index(inner_pos);
+    // split bits to 3 parts
+    size_type first_block_bits = min(n, BITS_PER_BLOCK - bit_index(inner_pos));
+    size_type inner_blocks = (n - first_block_bits) >> BLOCK_MOD_BITS;
+    size_type last_block_bits = (n - first_block_bits) & BLOCK_MOD_MASK;
+
+    // 1. set bits in the first block, starting from inner_pos
+    if (OB_UNLIKELY(first_block_bits == BITS_PER_BLOCK)) {
+      cur_mem_block->bits_[block_idx] = value ? uint64_t(-1) : 0ULL;
+    } else {
+      // (1ULL << x) -1 means a mask that low x bits are 1
+      // eg. x=3, mask=0000...0111
+      if (value) {
+        cur_mem_block->bits_[block_idx] |= ((1ULL << first_block_bits) - 1ULL)
+                                           << (inner_pos & BLOCK_MOD_MASK);
+      } else {
+        cur_mem_block->bits_[block_idx] &= ~(((1ULL << first_block_bits) - 1ULL)
+                                             << (inner_pos & BLOCK_MOD_MASK));
+      }
+    }
+    ++block_idx;
+
+    // 2. set bits by whole block
+    for (; inner_blocks > 0; --inner_blocks) {
+      if (OB_UNLIKELY(block_idx >= BLOCKS_PER_MEM_BLOCK)) {
+        cur_mem_block = cur_mem_block->next_;
+        block_idx = 0;
+      }
+      cur_mem_block->bits_[block_idx] = value ? uint64_t(-1) : 0ULL;
+      ++block_idx;
+    }
+
+    // 3. set rest bits in the last block
+    if (last_block_bits > 0) {
+      if (block_idx >= BLOCKS_PER_MEM_BLOCK) {
+        cur_mem_block = cur_mem_block->next_;
+        block_idx = 0;
+      }
+      if (value) {
+        cur_mem_block->bits_[block_idx] |= (1ULL << last_block_bits) - 1ULL;
+      } else {
+        cur_mem_block->bits_[block_idx] &= ~((1ULL << last_block_bits) - 1ULL);
+      }
     }
   }
   return ret;

--- a/src/sql/engine/basic/ob_pushdown_filter.cpp
+++ b/src/sql/engine/basic/ob_pushdown_filter.cpp
@@ -19,6 +19,7 @@
 #include "storage/blocksstable/encoding/ob_encoding_query_util.h"
 #include "storage/blocksstable/ob_datum_row.h"
 #include "sql/engine/expr/ob_expr_lob_utils.h"
+#include "storage/access/ob_aggregated_store.h"
 
 namespace oceanbase
 {
@@ -188,6 +189,7 @@ int ObPushdownFilterConstructor::is_white_mode(const ObRawExpr* raw_expr, bool &
       case T_OP_GE:
       case T_OP_GT:
       case T_OP_NE:
+      case T_OP_IN:
       case T_FUN_SYS_ISNULL:
         is_white = true;
         break;
@@ -962,39 +964,99 @@ int ObOrFilterExecutor::init_evaluated_datums()
 int ObWhiteFilterExecutor::init_evaluated_datums()
 {
   int ret = OB_SUCCESS;
-  ObEvalCtx &eval_ctx = op_.get_eval_ctx();
   if (OB_ISNULL(filter_.expr_)) {
     ret = OB_ERR_UNEXPECTED;
     LOG_WARN("Unexpected null expr", K(ret));
-  } else if (OB_FAIL(init_array_param(params_, filter_.expr_->arg_cnt_))) {
+  } else {
+    // load objs from datum
+    if (WHITE_OP_IN == filter_.get_op_type()) {
+      // fill params_ for WHITE_OP_IN
+      if (OB_FAIL(eval_in_right_val_to_objs())) {
+        LOG_WARN("Failed to eval right values to obj array for WHITE_OP_IN", K(ret));
+      } else if (OB_FAIL(init_obj_set())) {
+        LOG_WARN("Failed to init Object set in filter node", K(ret));
+      }
+    } else {
+      if (OB_FAIL(eval_right_val_to_objs())) {
+        LOG_WARN("Failed to eval right values to obj array for other OP except WHITE_OP_IN", K(ret), 
+                 K(filter_.get_op_type()));
+      }
+    }
+    LOG_DEBUG("[PUSHDOWN], white pushdown filter inited params", K(params_));
+  }
+  return ret;
+}
+
+int ObWhiteFilterExecutor::eval_right_val_to_objs()
+{
+  int ret = OB_SUCCESS;
+  const ObExpr &expr = *(filter_.expr_);
+  if (WHITE_OP_IN == filter_.get_op_type()) {
+    ret = OB_OP_NOT_ALLOW;
+    LOG_WARN("this function does not support WHITE_OP_IN", K(ret), K(filter_.get_op_type()));
+  } else if (OB_FAIL(init_array_param(params_, expr.arg_cnt_))) {
     LOG_WARN("Failed to alloc params", K(ret));
   } else {
-    for (int64_t i = 0; OB_SUCC(ret) && i < filter_.expr_->arg_cnt_; i++) {
-      if (OB_ISNULL(filter_.expr_->args_[i])) {
+    ObEvalCtx &ctx = op_.get_eval_ctx();
+    ObDatum *datum = NULL;
+    null_param_contained_ = false;
+    // fill params_ for other WHITE_OP_XX
+    ObObj param;
+    for (int64_t i = 0; OB_SUCC(ret) && i < expr.arg_cnt_; ++i) {
+      const ObExpr *cur_arg = expr.args_[i];
+      if (OB_ISNULL(cur_arg)) {
         ret = OB_ERR_UNEXPECTED;
         LOG_WARN("Unexpected null expr arguments", K(ret), K(i));
-      } else if (filter_.expr_->args_[i]->type_ == T_REF_COLUMN) {
+      } else if (cur_arg->type_ == T_REF_COLUMN) {
         // skip column reference expr
         continue;
       } else {
-        ObObj param;
-        ObDatum *datum = NULL;
-        if (OB_FAIL(filter_.expr_->args_[i]->eval(eval_ctx, datum))) {
+        if (OB_FAIL(cur_arg->eval(ctx, datum))) {
           LOG_WARN("evaluate filter arg expr failed", K(ret), K(i));
-        } else if (OB_FAIL(datum->to_obj(param, filter_.expr_->args_[i]->obj_meta_, filter_.expr_->args_[i]->obj_datum_map_))) {
+        } else if (OB_FAIL(datum->to_obj(param, cur_arg->obj_meta_, cur_arg->obj_datum_map_))) {
           LOG_WARN("convert datum to obj failed", K(ret));
+        } else if (!null_param_contained_ && datum->is_null()) {
+          null_param_contained_ = true;
         } else if (OB_FAIL(params_.push_back(param))) {
           LOG_WARN("Failed to push back param", K(ret));
         }
       }
     }
-    LOG_DEBUG("[PUSHDOWN], white pushdown filter inited params", K(params_));
   }
+  return ret;
+}
 
-  if (OB_SUCC(ret)) {
-    check_null_params();
-    if (WHITE_OP_IN == filter_.get_op_type() && OB_FAIL(init_obj_set())) {
-      LOG_WARN("Failed to init Object hash set in filter node", K(ret));
+int ObWhiteFilterExecutor::eval_in_right_val_to_objs()
+{
+  int ret = OB_SUCCESS;
+  const ObExpr &expr = *(filter_.expr_);
+  if (WHITE_OP_IN != filter_.get_op_type()) {
+    ret = OB_OP_NOT_ALLOW;
+    LOG_WARN("call this function but not WHITE_OP_IN", K(ret), K(filter_.get_op_type()));
+  } else if (OB_FAIL(init_array_param(params_, expr.inner_func_cnt_))) {
+    LOG_WARN("Failed to alloc params", K(ret));
+  } else {
+    ObEvalCtx &ctx = op_.get_eval_ctx();
+    // 参考 ObExprInOrNotIn::eval_in_without_row_fallback 实现
+    ObDatum *right = NULL;
+    null_param_contained_ = false;
+    // for each param of WHITE_OP_IN
+    // get right datum, transform to obj, append to params_
+    ObObj param;
+    for (int i = 0; OB_SUCC(ret) && i < expr.inner_func_cnt_; ++i) {
+      const ObExpr *cur_arg = expr.args_[1]->args_[i];
+      if (OB_ISNULL(cur_arg)) {
+        ret = OB_INVALID_ARGUMENT;
+        LOG_WARN("invalid null arg", K(ret), K(cur_arg), K(i));
+      } else if (OB_FAIL(cur_arg->eval(ctx, right))) {
+        LOG_WARN("failed to eval right datum", K(ret));
+      } else if (!null_param_contained_ && right->is_null()) {
+        null_param_contained_ = true;
+      } else if (OB_FAIL(right->to_obj(param, cur_arg->obj_meta_, cur_arg->obj_datum_map_))) {
+        LOG_WARN("convert datum to obj failed", K(ret));
+      } else if (OB_FAIL(params_.push_back(param))) {
+        LOG_WARN("Failed to push back param", K(ret));
+      }
     }
   }
   return ret;
@@ -1015,6 +1077,8 @@ void ObWhiteFilterExecutor::check_null_params()
 int ObWhiteFilterExecutor::init_obj_set()
 {
   int ret = OB_SUCCESS;
+  obj_array_sorted_ = false;
+  // 1. create obj hashset
   if (param_set_.created()) {
     param_set_.destroy();
   }
@@ -1030,20 +1094,43 @@ int ObWhiteFilterExecutor::init_obj_set()
       }
     }
   }
+  // 2. make params sorted
+  if (OB_FAIL(ret)) {
+  } else {
+    std::sort(params_.begin(), params_.end(), ObWhiteFilterParamsCmpFunc());
+    obj_array_sorted_ = true;
+  }
   return ret;
 }
 
 int ObWhiteFilterExecutor::exist_in_obj_set(const ObObj &obj, bool &is_exist) const
 {
   int ret = param_set_.exist_refactored(obj);
-  if (OB_HASH_EXIST == ret) {
-    ret = OB_SUCCESS;
-    is_exist = true;
-  } else if (OB_HASH_NOT_EXIST == ret) {
-    ret = OB_SUCCESS;
+    if (OB_HASH_EXIST == ret) {
+      ret = OB_SUCCESS;
+      is_exist = true;
+    } else if (OB_HASH_NOT_EXIST == ret) {
+      ret = OB_SUCCESS;
+      is_exist = false;
+    } else {
+      LOG_WARN("Failed to search in obj_set in pushed down filter node", K(ret), K(obj));
+    }
+  return ret;
+}
+
+int ObWhiteFilterExecutor::exist_in_obj_array(const ObObj &obj, bool &is_exist) const
+{
+  int ret = OB_SUCCESS;
+  // If params_.count() is small(<=8), the overhead of comparing with max/min values 
+  // becomes very large for the entire process, so skip it.
+  if (OB_UNLIKELY(!obj_array_sorted_)) {
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("Failed to check if exist, obj array not sorted", K(ret), K_(obj_array_sorted));
+  } else if (params_.count() > 8 && (obj < get_min_param() || obj > get_max_param())) {
+    // obj > max_obj || obj < min_obj
     is_exist = false;
   } else {
-    LOG_WARN("Failed to search in obj_set in pushed down filter node", K(ret), K(obj));
+    is_exist = std::binary_search(params_.begin(), params_.end(), obj, ObWhiteFilterParamsCmpFunc());
   }
   return ret;
 }
@@ -1617,6 +1704,130 @@ int ObPushdownOperator::deep_copy(const sql::ObExprPtrIArray *exprs, const int64
         }
       }
     }
+  }
+  return ret;
+}
+
+int ObWhiteFilterHashFunc::operator()(const common::ObObj &key, uint64_t &res) const {
+  return key.hash_murmur(res, 0);
+}
+
+PushdownFilterInfo::~PushdownFilterInfo()
+{
+  reset();
+}
+
+void PushdownFilterInfo::reset()
+{
+  if (nullptr != allocator_) {
+    if (nullptr != col_buf_) {
+      allocator_->free(col_buf_);
+      col_buf_ = nullptr;
+    }
+    if (nullptr != datum_buf_) {
+      allocator_->free(datum_buf_);
+      datum_buf_ = nullptr;
+    }
+    if (nullptr != cell_data_ptrs_) {
+      allocator_->free(cell_data_ptrs_);
+      cell_data_ptrs_ = nullptr;
+    }
+    if (nullptr != row_ids_) {
+      allocator_->free(row_ids_);
+      row_ids_ = nullptr;
+    }
+    if (nullptr != white_batch_datums_) {
+      allocator_->free(white_batch_datums_);
+      white_batch_datums_ = nullptr;
+    }
+    if (nullptr != white_batch_datums_buf_) {
+      allocator_->free(white_batch_datums_buf_);
+      white_batch_datums_buf_ = nullptr;
+    }
+    allocator_ = nullptr;
+  }
+  filter_ = nullptr;
+  is_inited_ = false;
+  is_pd_filter_ = false;
+  start_ = -1;
+  end_ = -1;
+  col_capacity_ = 0;
+  batch_size_ = 0;
+}
+
+void PushdownFilterInfo::reuse()
+{
+  filter_ = nullptr;
+  start_ = -1;
+  end_ = -1;
+}
+
+int PushdownFilterInfo::init(const storage::ObTableIterParam &iter_param,
+                             common::ObIAllocator &alloc,
+                             const bool need_padding) {
+  int ret = OB_SUCCESS;
+  void *buf = nullptr;
+  int64_t out_col_cnt = iter_param.get_out_col_cnt();
+  is_pd_filter_ = iter_param.enable_pd_filter();
+  allocator_ = &alloc;
+  if (IS_INIT) {
+    ret = OB_INIT_TWICE;
+    LOG_WARN("Init twice", K(ret));
+  } else if (OB_UNLIKELY(!iter_param.is_valid())) {
+    ret = OB_INVALID_ARGUMENT;
+    LOG_WARN("Invalid argument to init store pushdown filter", K(ret), K(iter_param));
+  } else if (nullptr == iter_param.pushdown_filter_) {
+    // nothing to do without filter exprs
+  } else if (OB_ISNULL((buf = alloc.alloc(sizeof(ObObj) * out_col_cnt)))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("Fail to allocate memory for pushdown filter col buf", K(ret), K(out_col_cnt));
+  } else if (FALSE_IT(col_buf_ = new (buf) ObObj[out_col_cnt]())) {
+  } else if (OB_ISNULL((buf = alloc.alloc(sizeof(blocksstable::ObStorageDatum) * out_col_cnt)))) {
+    ret = OB_ALLOCATE_MEMORY_FAILED;
+    LOG_WARN("Fail to allocate memory for pushdown filter col buf", K(ret), K(out_col_cnt));
+  } else if (FALSE_IT(datum_buf_ = new (buf) blocksstable::ObStorageDatum[out_col_cnt]())) {
+  } else if (OB_FAIL(iter_param.pushdown_filter_->init_filter_param(
+              *iter_param.get_col_params(), *iter_param.out_cols_project_, need_padding))) {
+    LOG_WARN("Failed to init pushdown filter executor", K(ret));
+  } else {
+    filter_ = iter_param.pushdown_filter_;
+    col_capacity_ = out_col_cnt;
+    is_inited_ = true;
+  }
+
+  if (OB_SUCC(ret) && (iter_param.vectorized_enabled_ || iter_param.enable_pd_aggregate())) {
+    // TODO: batch size too small for white filter IN?
+    batch_size_ = iter_param.vectorized_enabled_ ? iter_param.op_->get_batch_size() : ObAggregatedStore::BATCH_SIZE;
+    if (OB_ISNULL(buf = alloc.alloc(sizeof(char *) * batch_size_))) {
+      ret = common::OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("fail to alloc cell data ptr", K(ret), K(batch_size_));
+    } else if (FALSE_IT(cell_data_ptrs_ = reinterpret_cast<const char **>(buf))) {
+    } else if (OB_ISNULL(buf = alloc.alloc(sizeof(int64_t) * batch_size_))) {
+      ret = common::OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("fail to alloc row_ids", K(ret), K(batch_size_));
+    } else {
+      row_ids_ = reinterpret_cast<int64_t *>(buf);
+    }
+  }
+
+  if (OB_SUCC(ret) && (iter_param.vectorized_enabled_ && filter_->is_filter_white_node())) {
+    if (OB_ISNULL(buf = alloc.alloc(sizeof(ObDatum) * batch_size_))) {
+      ret = common::OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to alloc white_batch_datums_", K(ret), K(batch_size_));
+    } else if (FALSE_IT(white_batch_datums_ = reinterpret_cast<ObDatum *>(buf))) {
+    } else if (OB_ISNULL(buf = alloc.alloc(sizeof(int8_t) * OBJ_DATUM_MAX_RES_SIZE * batch_size_))) {
+      ret = common::OB_ALLOCATE_MEMORY_FAILED;
+      LOG_WARN("failed to alloc white_batch_datums_", K(ret), K(batch_size_));
+    } else if (FALSE_IT(white_batch_datums_buf_ = buf)) {
+    } else {
+      for (int64_t i = 0; i < batch_size_; ++i) {
+        white_batch_datums_[i].ptr_ = reinterpret_cast<char *>(white_batch_datums_buf_) + i * OBJ_DATUM_MAX_RES_SIZE;
+      }
+    }
+  }
+
+  if (IS_NOT_INIT) {
+    reset();
   }
   return ret;
 }

--- a/src/storage/access/ob_block_row_store.h
+++ b/src/storage/access/ob_block_row_store.h
@@ -15,6 +15,7 @@
 
 #include "common/object/ob_object.h"
 #include "lib/container/ob_bitmap.h"
+#include "sql/engine/basic/ob_pushdown_filter.h"
 #include "storage/ob_table_store_stat_mgr.h"
 
 namespace oceanbase
@@ -37,25 +38,6 @@ struct ObTableAccessContext;
 struct ObTableAccessParam;
 struct ObTableIterParam;
 struct ObStoreRow;
-struct PushdownFilterInfo
-{
-  PushdownFilterInfo() :
-      is_pd_filter_(false),
-      start_(-1),
-      end_(-1),
-      col_capacity_(0),
-      col_buf_(nullptr),
-      datum_buf_(nullptr),
-      filter_(nullptr) {}
-  bool is_pd_filter_;
-  int64_t start_;
-  int64_t end_;
-  int64_t col_capacity_;
-  // TODO remove col_buf_ later
-  common::ObObj *col_buf_;
-  blocksstable::ObStorageDatum *datum_buf_;
-  sql::ObPushdownFilterExecutor *filter_;
-};
 
 class ObBlockRowStore
 {
@@ -99,7 +81,7 @@ protected:
       sql::ObPushdownFilterExecutor *parent,
       sql::ObPushdownFilterExecutor *filter);
   bool is_inited_;
-  PushdownFilterInfo pd_filter_info_;
+  sql::PushdownFilterInfo pd_filter_info_;
   ObTableAccessContext &context_;
 private:
   bool can_blockscan_;

--- a/src/storage/blocksstable/encoding/ob_const_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_const_decoder.h
@@ -70,6 +70,7 @@ public:
       const sql::ObWhiteFilterExecutor &filter,
       const char* meta_data,
       const ObIRowIndex* row_index,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const override;
 protected:
   int decode_without_dict(const ObColumnDecoderCtx &ctx, common::ObObj &cell) const;

--- a/src/storage/blocksstable/encoding/ob_hex_string_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_hex_string_decoder.cpp
@@ -248,11 +248,12 @@ int ObHexStringDecoder::pushdown_operator(
     const sql::ObWhiteFilterExecutor &filter,
     const char* meta_data,
     const ObIRowIndex* row_index,
+    const sql::PushdownFilterInfo &pd_filter_info,
     ObBitmap &result_bitmap) const
 {
   // No enough meta data to improve comparison operation, so only implement is null, not null operator here
   // Other pushdown operators will retrograde to row-wise decode and compare
-  UNUSEDx(parent, meta_data);
+  UNUSEDx(parent, meta_data, pd_filter_info);
   int ret = OB_SUCCESS;
   const sql::ObWhiteFilterOperatorType op_type = filter.get_op_type();
   const char *col_data = reinterpret_cast<const char *>(header_) + col_ctx.col_header_->length_;

--- a/src/storage/blocksstable/encoding/ob_hex_string_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_hex_string_decoder.h
@@ -64,6 +64,7 @@ public:
       const sql::ObWhiteFilterExecutor &filter_node,
       const char* meta_data,
       const ObIRowIndex* row_index,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const override;
 private:
   const ObHexStringHeader *header_;

--- a/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_icolumn_decoder.h
@@ -132,9 +132,10 @@ public:
       const sql::ObWhiteFilterExecutor &filter,
       const char* meta_data,
       const ObIRowIndex* row_index,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const
   {
-    UNUSEDx(parent, col_ctx, filter, meta_data, row_index, result_bitmap);
+    UNUSEDx(parent, col_ctx, filter, meta_data, row_index, pd_filter_info, result_bitmap);
     return common::OB_NOT_SUPPORTED;
   }
 

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.cpp
@@ -221,6 +221,7 @@ int ObIntegerBaseDiffDecoder::pushdown_operator(
     const sql::ObWhiteFilterExecutor &filter,
     const char* meta_data,
     const ObIRowIndex* row_index,
+    const sql::PushdownFilterInfo &pd_filter_info,
     ObBitmap &result_bitmap) const
 {
   UNUSEDx(meta_data, row_index);
@@ -261,7 +262,7 @@ int ObIntegerBaseDiffDecoder::pushdown_operator(
                   col_data,
                   filter,
                   result_bitmap))) {
-        LOG_WARN("Failed on EQ / NE operator", K(ret), K(col_ctx));
+        LOG_WARN("Failed on COMPARISON operator", K(ret), K(col_ctx));
       }
       break;
     }
@@ -272,7 +273,7 @@ int ObIntegerBaseDiffDecoder::pushdown_operator(
       break;
     }
     case sql::WHITE_OP_IN: {
-      if (OB_FAIL(in_operator(parent, col_ctx, col_data, filter, result_bitmap))) {
+      if (OB_FAIL(in_operator(parent, col_ctx, col_data, filter, pd_filter_info, result_bitmap))) {
         LOG_WARN("Failed on IN operator", K(ret), K(col_ctx));
       }
       break;
@@ -334,108 +335,55 @@ int ObIntegerBaseDiffDecoder::comparison_operator(
     ObBitmap &result_bitmap) const
 {
   int ret = OB_SUCCESS;
-  uint64_t delta_value = 0;
-  uint64_t param_delta_value = 0;
-  if (OB_UNLIKELY(col_ctx.micro_block_header_->row_count_ != result_bitmap.size()
-                          || NULL == col_data
-                          || filter.get_objs().count() != 1)) {
+  ObObjTypeStoreClass column_sc = get_store_class_map()[col_ctx.obj_meta_.get_type_class()];
+  if (OB_UNLIKELY(NULL == col_data
+                  || result_bitmap.size() != col_ctx.micro_block_header_->row_count_ 
+                  || filter.get_objs().count() != 1
+                  || filter.get_op_type() > sql::WHITE_OP_NE
+                  || filter.null_param_contained())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Filter Pushdown Operator: Invalid argument", K(ret), K(col_ctx));
   } else if (OB_UNLIKELY(col_ctx.obj_meta_.get_type() != filter.get_objs().at(0).get_type())) {
     // Filter type not match with column type, back to retro path
     ret = OB_NOT_SUPPORTED;
     LOG_DEBUG("Type not match, back to retrograde path", K(col_ctx), K(filter));
-  } else if (col_ctx.obj_meta_.get_type_class() == ObFloatTC
-            || col_ctx.obj_meta_.get_type_class() == ObDoubleTC) {
-    // Can't compare by uint directly, support this later with float point number compare later
-    ret = OB_NOT_SUPPORTED;
-    LOG_DEBUG("Double/Float with INT_DIFF encoding, back to retro path", K(col_ctx));
+  } else if (OB_UNLIKELY((column_sc != ObIntSC) && (column_sc != ObUIntSC))) { 
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("Integer base encoding should only encode data as IntSC or UIntSC", K(ret), K(filter));
   } else {
-    const ObObj &ref_obj = filter.get_objs().at(0);
     ObObj base_obj;
     base_obj.copy_meta_type(col_ctx.obj_meta_);
     base_obj.v_.uint64_ = base_;
-    ObObjTypeStoreClass column_sc = get_store_class_map()[col_ctx.obj_meta_.get_type_class()];
-    bool filter_obj_smaller_than_base = ref_obj < base_obj;
+    bool filter_obj_smaller_than_base = filter.get_objs().at(0) < base_obj;
 
     ObFPIntCmpOpType cmp_op_type = get_white_op_int_op_map()[filter.get_op_type()];
     if (filter_obj_smaller_than_base) {
       // Do not need to decode the data
-      if ((filter_obj_smaller_than_base
-              && (cmp_op_type == FP_INT_OP_GE || cmp_op_type == FP_INT_OP_GT))
-          || cmp_op_type == FP_INT_OP_NE) {
+      if ((cmp_op_type == FP_INT_OP_GE || cmp_op_type == FP_INT_OP_GT) ||
+          cmp_op_type == FP_INT_OP_NE) {
         // All rows except null value are true
         if (OB_FAIL(result_bitmap.bit_not())) {
           LOG_WARN("Failed to flip all bits in bitmap", K(ret));
         }
-      } else  {
+      } else {
         // All rows are false;
         result_bitmap.reuse();
       }
     } else {
-      uint8_t cell_len = header_->length_;
-      int64_t data_offset = 0;
-      bool null_value_contained = result_bitmap.popcnt() > 0;
-      bool exist_parent_filter = nullptr != parent;
-      if (col_ctx.has_extend_value()) {
-        data_offset = col_ctx.micro_block_header_->row_count_
-            * col_ctx.micro_block_header_->extend_value_bit_;
-      }
-      if (ObIntSC == column_sc) {
-        if (OB_FAIL(get_delta<int64_t>(ref_obj, param_delta_value))) {
-          LOG_WARN("Failed to get delta value", K(ret), K(ref_obj));
-        }
-      } else if (ObUIntSC == column_sc) {
-        if (OB_FAIL(get_delta<uint64_t>(ref_obj, param_delta_value))) {
-          LOG_WARN("Failed to get delta value", K(ret), K(ref_obj));
-        }
-      } else {
-        ret = OB_ERR_UNEXPECTED;
-        LOG_WARN("Unexpected Store type for int_diff decoder", K(ret), K(column_sc));
-      }
-
+      // traverse and decode all data
+      // do compare row by row
       if (OB_FAIL(ret)) {
-      } else if (col_ctx.is_bit_packing()) {
-        for (int64_t row_id = 0;
-            OB_SUCC(ret) && row_id < col_ctx.micro_block_header_->row_count_;
-            ++row_id) {
-          if (exist_parent_filter && parent->can_skip_filter(row_id)) {
-          } else if (null_value_contained && result_bitmap.test(row_id)) {
-            if (OB_FAIL(result_bitmap.set(row_id, false))) {
-              LOG_WARN("Failed to set row with null object to false", K(ret));
-            }
-          } else if (OB_FAIL(ObBitStream::get(
-                col_data, data_offset + row_id * cell_len, cell_len, delta_value))) {
-              LOG_WARN("Failed to get bit packing value", K(ret), K_(header));
-          } else {
-            bool cmp_result = fp_int_cmp<uint64_t>(delta_value, param_delta_value, cmp_op_type);
-            if (cmp_result) {
-              if (OB_FAIL(result_bitmap.set(row_id))) {
-                LOG_WARN("Failed to set result bitmap", K(ret), K(row_id), K(filter));
-              }
-            }
-          }
-        }
-      } else {
-        data_offset = (data_offset + CHAR_BIT - 1) / CHAR_BIT;
-        for (int64_t row_id = 0;
-            OB_SUCC(ret) && row_id < col_ctx.micro_block_header_->row_count_;
-            ++row_id) {
-          if (exist_parent_filter && parent->can_skip_filter(row_id)) {
-          } else if (null_value_contained && result_bitmap.test(row_id)) {
-            if (OB_FAIL(result_bitmap.set(row_id, false))) {
-              LOG_WARN("Failed to set row with null object to false", K(ret));
-            }
-          } else {
-            MEMCPY(&delta_value, col_data + data_offset + row_id * cell_len, cell_len);
-            bool cmp_result = fp_int_cmp<uint64_t>(delta_value, param_delta_value, cmp_op_type);
-            if (cmp_result) {
-              if (OB_FAIL(result_bitmap.set(row_id))) {
-                LOG_WARN("Failed to set result bitmap", K(ret), K(row_id), K(filter));
-              }
-            }
-          }
-        }
+      } else if (OB_FAIL(traverse_all_data(
+                     parent, col_ctx, col_data, filter, result_bitmap,
+                     cmp_op_type,
+                     [](const ObObj &cur_obj,
+                        const sql::ObWhiteFilterExecutor &filter,
+                        bool &result,
+                        const ObFPIntCmpOpType &cmp_op_type) -> int {
+                       result = fp_int_cmp<ObObj>(cur_obj, filter.get_objs().at(0), cmp_op_type);
+                       return OB_SUCCESS;
+                     }))) {
+        LOG_WARN("Failed to traverse all data in micro block", K(ret));
       }
     }
   }
@@ -450,41 +398,58 @@ int ObIntegerBaseDiffDecoder::bt_operator(
     ObBitmap &result_bitmap) const
 {
   int ret = OB_SUCCESS;
-  if (OB_UNLIKELY(col_ctx.micro_block_header_->row_count_ != result_bitmap.size()
-                          || NULL == col_data
-                          || filter.get_objs().count() != 2)) {
+  ObObjTypeStoreClass column_sc = get_store_class_map()[col_ctx.obj_meta_.get_type_class()];
+  const ObObj &obj_left = filter.get_objs().at(0);
+  const ObObj &obj_right = filter.get_objs().at(1);
+  if (OB_UNLIKELY(NULL == col_data
+                  || result_bitmap.size() != col_ctx.micro_block_header_->row_count_
+                  || filter.get_objs().count() != 2
+                  || filter.get_op_type() != sql::WHITE_OP_BT
+                  || filter.null_param_contained())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Filter pushdown operator: Invalid argument", K(ret), K(col_ctx));
-  } else if (col_ctx.obj_meta_.get_type_class() == ObFloatTC
-            || col_ctx.obj_meta_.get_type_class() == ObDoubleTC) {
-    // Can't compare by uint directly, support this later with float point number compare later
-    ret = OB_NOT_SUPPORTED;
-    LOG_DEBUG("Double/Float with INT_DIFF encoding, back to retro path", K(col_ctx));
-  } else if (ObUIntSC == get_store_class_map()[filter.get_objs().at(0).get_type_class()]) {
-    if (OB_FAIL(traverse_all_data(parent, col_ctx, col_data, filter, result_bitmap,
-                [](uint64_t &cur_int,
-                const sql::ObWhiteFilterExecutor &filter,
-                bool &result) -> int {
-                  result = (cur_int >= filter.get_objs().at(0).v_.uint64_)
-                            && (cur_int <= filter.get_objs().at(1).v_.uint64_);
-                  return OB_SUCCESS;
-                }))) {
-      LOG_WARN("Failed to traverse all data in micro block", K(ret));
-    }
-  } else if (ObIntSC == get_store_class_map()[filter.get_objs().at(0).get_type_class()]) {
-    if (OB_FAIL(traverse_all_data(parent, col_ctx, col_data, filter, result_bitmap,
-                [](uint64_t &cur_int,
-                const sql::ObWhiteFilterExecutor &filter,
-                bool &result) -> int {
-                  result = (cur_int >= filter.get_objs().at(0).v_.int64_)
-                            && (cur_int <= filter.get_objs().at(1).v_.int64_);
-                  return OB_SUCCESS;
-                }))) {
-      LOG_WARN("Failed to traverse all data in micro block", K(ret));
-    }
-  } else {
+  } else if (OB_UNLIKELY((column_sc != ObIntSC) && (column_sc != ObUIntSC))) { 
     ret = OB_ERR_UNEXPECTED;
-    LOG_WARN("Integer base encoding should only encode data as IntSC", K(ret), K(filter));
+    LOG_WARN("Integer base encoding should only encode data as IntSC or UIntSC", K(ret), K(filter));
+  } else if (OB_UNLIKELY((col_ctx.obj_meta_.get_type() != filter.get_objs().at(0).get_type())
+                         || (col_ctx.obj_meta_.get_type() != filter.get_objs().at(1).get_type()))) {
+    // Filter type not match with column type or obj0 type not match with obj1
+    // back to retro path
+    ret = OB_NOT_SUPPORTED;
+    LOG_DEBUG("Type not match, back to retrograde path", K(col_ctx), K(filter));
+  } else if (obj_left > obj_right){
+    // Between left bound large than right bound
+    // return all-false bitmap
+    result_bitmap.reuse();
+    LOG_DEBUG("Hit shortcut, obj_left > obj_right, return all-false bitmap", K(obj_right), K(obj_right));
+  } else {
+    ObObj base_obj;
+    base_obj.copy_meta_type(col_ctx.obj_meta_);
+    base_obj.v_.uint64_ = base_;
+    bool filter_obj_smaller_than_base = obj_right < base_obj;
+
+    if (filter_obj_smaller_than_base) {
+      // Do not need to decode the data
+      // All rows are false
+      result_bitmap.reuse();
+      LOG_DEBUG("Hit shortcut, obj_right < base_obj, return all-false bitmap", K(obj_right), K(base_obj));
+    } else {
+      // traverse and decode all data
+      // do compare row by row
+      if (OB_FAIL(ret)) {
+      } else if (OB_FAIL(traverse_all_data(
+                     parent, col_ctx, col_data, filter, result_bitmap, FP_INT_OP_MAX,
+                     [](const ObObj &cur_obj,
+                        const sql::ObWhiteFilterExecutor &filter,
+                        bool &result,
+                        const ObFPIntCmpOpType &cmp_op_type) -> int {
+                       result = (cur_obj >= filter.get_objs().at(0))
+                                 && (cur_obj <= filter.get_objs().at(1));
+                       return OB_SUCCESS;
+                     }))) {
+        LOG_WARN("Failed to traverse all data in micro block", K(ret));
+      }
+    }
   }
   return ret;
 }
@@ -494,26 +459,100 @@ int ObIntegerBaseDiffDecoder::in_operator(
     const ObColumnDecoderCtx &col_ctx,
     const unsigned char* col_data,
     const sql::ObWhiteFilterExecutor &filter,
+    const sql::PushdownFilterInfo &pd_filter_info,
     ObBitmap &result_bitmap) const
 {
   int ret = OB_SUCCESS;
-  if (OB_UNLIKELY(filter.get_objs().count() == 0
-                  || result_bitmap.size() != col_ctx.micro_block_header_->row_count_)) {
+  ObObjTypeStoreClass column_sc = get_store_class_map()[col_ctx.obj_meta_.get_type_class()];
+  if (OB_UNLIKELY(NULL == col_data
+                  || result_bitmap.size() != col_ctx.micro_block_header_->row_count_
+                  || filter.get_objs().count() == 0
+                  || filter.get_op_type() != sql::WHITE_OP_IN
+                  || filter.null_param_contained())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Pushdown in operator: Invalid arguments");
-  } else if (OB_FAIL(traverse_all_data(parent, col_ctx, col_data, filter, result_bitmap,
-                      [](uint64_t &cur_int,
-                          const sql::ObWhiteFilterExecutor &filter,
-                          bool &result) -> int {
-                        int ret = OB_SUCCESS;
-                        ObObj cur_obj(filter.get_objs().at(0));
-                        cur_obj.v_.uint64_ = cur_int;
-                        if (OB_FAIL(filter.exist_in_obj_set(cur_obj, result))) {
-                          LOG_WARN("Failed to check object in hashset", K(ret), K(cur_obj));
-                        }
-                        return ret;
-                      }))) {
-    LOG_WARN("Failed to traverse all data in micro block", K(ret));
+  } else if (OB_UNLIKELY((column_sc != ObIntSC) && (column_sc != ObUIntSC))) { 
+    ret = OB_ERR_UNEXPECTED;
+    LOG_WARN("Integer base encoding should only encode data as IntSC or UIntSC", K(ret), K(filter));
+  } else {
+    ObObj base_obj;
+    base_obj.copy_meta_type(col_ctx.obj_meta_);
+    base_obj.v_.uint64_ = base_;
+    // use max(obj_set) compare with base
+    bool filter_obj_smaller_than_base = filter.is_obj_array_sorted() && (filter.get_max_param() < base_obj);
+
+    if (filter_obj_smaller_than_base) {
+      // Do not need to decode the data
+      // All rows are false
+      result_bitmap.reuse();
+      LOG_DEBUG("Hit shortcut, max(obj_set) < base_obj, return all-false bitmap", K(base_obj));
+    } else if (OB_LIKELY(can_vectorized()) && OB_LIKELY(is_inited())) {
+      // prepare arguments
+      int64_t cur_row_id = 0;
+      int64_t end_row_id = col_ctx.micro_block_header_->row_count_;
+      int64_t last_start = cur_row_id;
+      int64_t row_cap = 0;
+      ObDatum *datums = pd_filter_info.white_batch_datums_;
+      bool null_value_contained = (result_bitmap.popcnt() > 0);
+      ObObj cur_obj;
+      bool result = false;
+      // filter by batch
+      while (OB_SUCC(ret) && cur_row_id < end_row_id) {
+        last_start = cur_row_id;
+        row_cap = min(pd_filter_info.batch_size_, end_row_id - cur_row_id);
+        cur_row_id += row_cap;
+        // 1. prepare row_ids
+        for (int64_t i = 0; i < row_cap; ++i) {
+          pd_filter_info.row_ids_[i] = last_start + i;
+        }
+        // 2. batch decode
+        if (OB_FAIL(batch_decode(col_ctx, NULL, pd_filter_info.row_ids_,
+                                pd_filter_info.cell_data_ptrs_, row_cap,
+                                datums))) {
+          LOG_WARN("Failed to batch decode", K(ret), K(row_cap));
+        } else {
+          // 3. traverse all datums row by row
+          for (int64_t row_id = last_start; OB_SUCC(ret) && row_id < cur_row_id; ++row_id) {
+            const int64_t buf_id = row_id - last_start;
+            if (nullptr != parent && parent->can_skip_filter(row_id)) {
+              continue;
+            } else if (null_value_contained && result_bitmap.test(row_id)) {
+              // object in this row is null
+              if (OB_FAIL(result_bitmap.set(row_id, false))) {
+                LOG_WARN("Failed to set null value to false", K(ret));
+              }
+            } else {
+              if (OB_FAIL(datums[buf_id].to_obj(cur_obj, col_ctx.obj_meta_))) {
+                LOG_WARN("Failed to transform datum to obj", K(ret), K(datums[buf_id]));
+              } else if (OB_FAIL(filter.exist_in_obj_set(cur_obj, result))) {
+                LOG_WARN("Failed to check object in obj set", K(ret), K(cur_obj));
+              } else if (result && OB_FAIL(result_bitmap.set(row_id))) {
+                LOG_WARN("Failed to set result bitmap", K(ret), K(row_id), K(filter));
+              }
+            }
+          }
+        }
+      }
+      LOG_TRACE("in_operator use batch decode successfully", K(ret), K(col_ctx.is_fix_length()));
+    } else {
+      // traverse and decode all data
+      // do compare row by row
+      if (OB_FAIL(ret)) {
+      } else if (OB_FAIL(traverse_all_data(
+                     parent, col_ctx, col_data, filter, result_bitmap, FP_INT_OP_MAX,
+                     [](const ObObj &cur_obj,
+                        const sql::ObWhiteFilterExecutor &filter,
+                        bool &result,
+                        const ObFPIntCmpOpType &cmp_op_type) -> int {
+                       int ret = OB_SUCCESS;
+                       if (OB_FAIL(filter.exist_in_obj_set(cur_obj, result))) {
+                         LOG_WARN("Failed to check object in obj_set", K(ret), K(cur_obj));
+                       }
+                       return ret;
+                     }))) {
+        LOG_WARN("Failed to traverse all data in micro block", K(ret));
+      }
+    }
   }
   return ret;
 }
@@ -524,14 +563,16 @@ int ObIntegerBaseDiffDecoder::traverse_all_data(
     const unsigned char* col_data,
     const sql::ObWhiteFilterExecutor &filter,
     ObBitmap &result_bitmap,
+    const ObFPIntCmpOpType &cmp_op_type,
     int (*lambda)(
-        uint64_t &cur_int,
+        const ObObj &cur_obj,
         const sql::ObWhiteFilterExecutor &filter,
-        bool &result)) const
+        bool &result,
+        const ObFPIntCmpOpType &cmp_op_type)) const
 {
   int ret = OB_SUCCESS;
   uint64_t v = 0;
-  uint64_t cur_int = 0;
+  ObObj cur_obj;
   uint8_t cell_len = header_->length_;
   int64_t data_offset = 0;
   if (col_ctx.has_extend_value()) {
@@ -543,6 +584,10 @@ int ObIntegerBaseDiffDecoder::traverse_all_data(
   }
   bool null_value_contained = (result_bitmap.popcnt() > 0);
   bool exist_parent_filter = nullptr != parent;
+  sql::ObWhiteFilterOperatorType op_type = filter.get_op_type();
+
+  // copy meta, include storage type (Int64/UInt64)
+  cur_obj.copy_meta_type(col_ctx.obj_meta_);
   for (int64_t row_id = 0;
        OB_SUCC(ret) && row_id < col_ctx.micro_block_header_->row_count_;
        ++row_id) {
@@ -561,11 +606,11 @@ int ObIntegerBaseDiffDecoder::traverse_all_data(
         MEMCPY(&v, col_data + data_offset + row_id * cell_len, cell_len);
       }
       if (OB_SUCC(ret)) {
-        cur_int = base_ + v;
+        cur_obj.v_.uint64_ = base_ + v;
         // use lambda here to filter and set result bitmap
         bool result = false;
-        if (OB_FAIL(lambda(cur_int, filter, result))) {
-          LOG_WARN("Failed on trying to filter the row", K(ret), K(row_id), K(cur_int));
+        if (OB_FAIL(lambda(cur_obj, filter, result, cmp_op_type))) {
+          LOG_WARN("Failed on trying to filter the row", K(ret), K(row_id), K(cur_obj.v_.uint64_));
         } else if (result) {
           if (OB_FAIL(result_bitmap.set(row_id))) {
             LOG_WARN("Failed to set result bitmap", K(ret), K(row_id), K(filter));

--- a/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_integer_base_diff_decoder.h
@@ -64,6 +64,7 @@ public:
       const sql::ObWhiteFilterExecutor &filter,
       const char* meta_data,
       const ObIRowIndex* row_index,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const override;
 
   virtual int get_null_count(
@@ -109,6 +110,7 @@ private:
       const ObColumnDecoderCtx &col_ctx,
       const unsigned char* col_data,
       const sql::ObWhiteFilterExecutor &filter,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const;
 
   int traverse_all_data(
@@ -117,10 +119,12 @@ private:
       const unsigned char* col_data,
       const sql::ObWhiteFilterExecutor &filter,
       ObBitmap &result_bitmap,
+      const ObFPIntCmpOpType &cmp_op_type,
       int (*lambda)(
-          uint64_t &cur_int,
+          const ObObj &cur_obj,
           const sql::ObWhiteFilterExecutor &filter,
-          bool &result)) const;
+          bool &result,
+          const ObFPIntCmpOpType &cmp_op_type)) const;
 private:
   const ObIntegerBaseDiffHeader *header_;
   uint64_t base_;

--- a/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_micro_block_decoder.cpp
@@ -1879,7 +1879,7 @@ int ObMicroBlockDecoder::get_multi_version_info(
 int ObMicroBlockDecoder::filter_pushdown_filter(
     const sql::ObPushdownFilterExecutor *parent,
     sql::ObBlackFilterExecutor &filter,
-    const storage::PushdownFilterInfo &pd_filter_info,
+    const sql::PushdownFilterInfo &pd_filter_info,
     common::ObBitmap &result_bitmap)
 {
   int ret = OB_SUCCESS;
@@ -1937,7 +1937,7 @@ int ObMicroBlockDecoder::filter_pushdown_filter(
 int ObMicroBlockDecoder::filter_pushdown_filter(
     const sql::ObPushdownFilterExecutor *parent,
     sql::ObWhiteFilterExecutor &filter,
-    const storage::PushdownFilterInfo &pd_filter_info,
+    const sql::PushdownFilterInfo &pd_filter_info,
     ObBitmap &result_bitmap)
 {
   int ret = OB_SUCCESS;
@@ -1984,6 +1984,7 @@ int ObMicroBlockDecoder::filter_pushdown_filter(
                 filter,
                 meta_data_,
                 row_index_,
+                pd_filter_info,
                 result_bitmap))) {
       if (OB_LIKELY(ret == OB_NOT_SUPPORTED)) {
         LOG_TRACE("[PUSHDOWN] Column specific operator failed, switch to retrograde filter pushdown",
@@ -2016,7 +2017,7 @@ int ObMicroBlockDecoder::filter_pushdown_filter(
 int ObMicroBlockDecoder::filter_pushdown_retro(
     const sql::ObPushdownFilterExecutor *parent,
     sql::ObWhiteFilterExecutor &filter,
-    const storage::PushdownFilterInfo &pd_filter_info,
+    const sql::PushdownFilterInfo &pd_filter_info,
     const int32_t col_offset,
     const share::schema::ObColumnParam *col_param,
     common::ObObj &decoded_obj,

--- a/src/storage/blocksstable/encoding/ob_micro_block_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_micro_block_decoder.h
@@ -24,9 +24,6 @@
 
 namespace oceanbase
 {
-namespace storage {
-struct PushdownFilterInfo;
-}
 namespace blocksstable
 {
 struct ObBlockCachedDecoderHeader;
@@ -235,17 +232,17 @@ public:
   int filter_pushdown_filter(
       const sql::ObPushdownFilterExecutor *parent,
       sql::ObBlackFilterExecutor &filter,
-      const storage::PushdownFilterInfo &pd_filter_info,
+      const sql::PushdownFilterInfo &pd_filter_info,
       common::ObBitmap &result_bitmap);
   int filter_pushdown_filter(
       const sql::ObPushdownFilterExecutor *parent,
       sql::ObWhiteFilterExecutor &filter,
-      const storage::PushdownFilterInfo &pd_filter_info,
+      const sql::PushdownFilterInfo &pd_filter_info,
       common::ObBitmap &result_bitmap);
   int filter_pushdown_retro(
       const sql::ObPushdownFilterExecutor *parent,
       sql::ObWhiteFilterExecutor &filter,
-      const storage::PushdownFilterInfo &pd_filter_info,
+      const sql::PushdownFilterInfo &pd_filter_info,
       const int32_t col_offset,
       const share::schema::ObColumnParam *col_param,
       common::ObObj &decoded_obj,

--- a/src/storage/blocksstable/encoding/ob_raw_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_raw_decoder.h
@@ -104,6 +104,7 @@ public:
       const sql::ObWhiteFilterExecutor &filter,
       const char* meta_data,
       const ObIRowIndex* row_index,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const override;
 
   virtual int get_null_count(
@@ -165,6 +166,7 @@ private:
       const unsigned char* col_data,
       const ObIRowIndex* row_index,
       const sql::ObWhiteFilterExecutor &filter,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const;
 
   int load_data_to_obj_cell(const ObObjMeta cell_meta, const char *cell_data, int64_t cell_len, ObObj &load_obj) const;

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.cpp
@@ -126,9 +126,10 @@ int ObRLEDecoder::pushdown_operator(
     const sql::ObWhiteFilterExecutor &filter,
     const char* meta_data,
     const ObIRowIndex* row_index,
+    const sql::PushdownFilterInfo &pd_filter_info,
     ObBitmap &result_bitmap) const
 {
-  UNUSEDx(meta_data, row_index);
+  UNUSEDx(meta_data, row_index, pd_filter_info);
   int ret = OB_SUCCESS;
   const sql::ObWhiteFilterOperatorType op_type = filter.get_op_type();
   if (OB_UNLIKELY(!is_inited())) {
@@ -270,6 +271,7 @@ int ObRLEDecoder::comparison_operator(
   int ret = OB_SUCCESS;
   if (OB_UNLIKELY(result_bitmap.size() != col_ctx.micro_block_header_->row_count_
                   || filter.get_objs().count() != 1
+                  || filter.get_op_type() > sql::WHITE_OP_NE
                   || filter.null_param_contained())) {
     ret = OB_INVALID_ARGUMENT;
     LOG_WARN("Invalid argument for comparison operator", K(ret),
@@ -317,7 +319,8 @@ int ObRLEDecoder::bt_operator(
   int ret = OB_SUCCESS;
   if (OB_UNLIKELY(result_bitmap.size() != col_ctx.micro_block_header_->row_count_
                 || filter.get_objs().count() != 2
-                || filter.get_op_type() != sql::WHITE_OP_BT)) {
+                || filter.get_op_type() != sql::WHITE_OP_BT
+                || filter.null_param_contained())) {
       ret = OB_INVALID_ARGUMENT;
       LOG_WARN("Invalid argument for BT operator",
           K(ret), K(result_bitmap.size()), K(filter.get_objs()));
@@ -360,31 +363,45 @@ int ObRLEDecoder::in_operator(
   int ret = OB_SUCCESS;
   if (OB_UNLIKELY(result_bitmap.size() != col_ctx.micro_block_header_->row_count_
                   || filter.get_objs().count() == 0
-                  || filter.get_op_type() != sql::WHITE_OP_IN)) {
-    LOG_WARN("Invalid argument for BT operator", K(ret),
+                  || filter.get_op_type() != sql::WHITE_OP_IN
+                  || filter.null_param_contained())) {
+    LOG_WARN("Invalid argument for IN operator", K(ret),
              K(result_bitmap.size()), K(filter));
   } else {
-    const int64_t dict_count = dict_decoder_.get_dict_header()->count_;
-    if (dict_count > 0) {
-      bool found = false;
+    const ObDictMetaHeader* dict_meta_header = dict_decoder_.get_dict_header();
+    if (OB_UNLIKELY(OB_ISNULL(dict_meta_header))) {
+      LOG_WARN("dict meta header is NULL", K(ret));
+    } else if (dict_meta_header->count_ > 0) {
       const int64_t dict_meta_length = col_ctx.col_header_->length_ - meta_header_->offset_;
-      ObDictDecoderIterator end_it = dict_decoder_.end(&col_ctx, dict_meta_length);
-      ObDictDecoderIterator traverse_it = dict_decoder_.begin(&col_ctx, dict_meta_length);
-      const int64_t ref_bitset_size = dict_count + 1;
+      // iterators
+      ObDictDecoderIterator left_it = dict_decoder_.begin(&col_ctx, dict_meta_length);
+      ObDictDecoderIterator right_it = dict_decoder_.end(&col_ctx, dict_meta_length);
+      // init ref_bitset
+      const int64_t ref_bitset_size = dict_meta_header->count_ + 1;
       char ref_bitset_buf[sql::ObBitVector::memory_size(ref_bitset_size)];
       sql::ObBitVector *ref_bitset = sql::to_bit_vector(ref_bitset_buf);
       ref_bitset->init(ref_bitset_size);
-      int64_t dict_ref = 0;
-      bool is_exist = false;
-      while (OB_SUCC(ret) && traverse_it != end_it) {
-        if (OB_FAIL(filter.exist_in_obj_set(*traverse_it, is_exist))) {
-          LOG_WARN("Failed to check object in hashset", K(ret), K(*traverse_it));
-        } else if (is_exist) {
-          found = true;
-          ref_bitset->set(dict_ref);
+      // common variables
+      bool found = false;
+      bool is_hit_shortcut = false;
+      bool is_sorted_dict = dict_meta_header->is_sorted_dict();
+
+      if (is_sorted_dict && filter.is_obj_array_sorted()) {
+        // Sorted dictionary, binary search here to find boundary element
+        left_it = std::lower_bound(left_it, right_it, filter.get_min_param());
+        right_it = std::upper_bound(left_it, right_it, filter.get_max_param());
+        if (left_it == right_it) {
+          is_hit_shortcut = true;
+          LOG_DEBUG("Hit shortcut, no cross, return all-false bitmap", K(*left_it));
         }
-        ++traverse_it;
-        ++dict_ref;
+      }
+
+      if (!is_hit_shortcut &&
+          OB_FAIL(dict_decoder_.set_ref_exist_in_objs(
+              left_it, right_it,
+              dict_decoder_.begin(&col_ctx, dict_meta_length), is_sorted_dict,
+              filter, *ref_bitset, found))) {
+        LOG_WARN("Failed to check object in objs", K(ret));
       }
       if (found && OB_FAIL(set_res_with_bitset(parent, col_ctx, ref_bitset, result_bitmap))) {
         LOG_WARN("Failed to set result_bitmap", K(ret));
@@ -417,10 +434,8 @@ int ObRLEDecoder::cmp_ref_and_set_res(
       next_row_id = i != meta_header_->count_ - 1
                           ? row_ids.at_(meta_header_->payload_, i + 1)
                           : col_ctx.micro_block_header_->row_count_;
-      for (int64_t idx = row_id; OB_SUCC(ret) && idx < next_row_id; ++idx) {
-        if (OB_FAIL(result_bitmap.set(idx, flag))) {
-          LOG_WARN("Failed to set result_bitmap", K(ret), K(row_id), K(next_row_id), K(idx));
-        }
+      if (OB_FAIL(result_bitmap.set_n(row_id, next_row_id - row_id, flag))) {
+        LOG_WARN("Failed to set_n result_bitmap", K(ret), K(row_id), K(next_row_id));
       }
     }
   }
@@ -447,10 +462,8 @@ int ObRLEDecoder::set_res_with_bitset(
       next_row_id = i != meta_header_->count_ - 1
                           ? row_ids.at_(meta_header_->payload_, i + 1)
                           : col_ctx.micro_block_header_->row_count_;
-      for (int64_t idx = row_id; OB_SUCC(ret) && idx < next_row_id; ++idx) {
-        if (OB_FAIL(result_bitmap.set(idx))) {
-          LOG_WARN("Failed to set result_bitmap", K(ret), K(row_id), K(next_row_id), K(idx));
-        }
+      if (OB_FAIL(result_bitmap.set_n(row_id, next_row_id - row_id))) {
+        LOG_WARN("Failed to set_n result_bitmap", K(ret), K(row_id), K(next_row_id));
       }
     }
   }

--- a/src/storage/blocksstable/encoding/ob_rle_decoder.h
+++ b/src/storage/blocksstable/encoding/ob_rle_decoder.h
@@ -75,6 +75,7 @@ public:
       const sql::ObWhiteFilterExecutor &filter,
       const char* meta_data,
       const ObIRowIndex* row_index,
+      const sql::PushdownFilterInfo &pd_filter_info,
       ObBitmap &result_bitmap) const override;
 
 private:

--- a/src/storage/blocksstable/ob_imicro_block_reader.cpp
+++ b/src/storage/blocksstable/ob_imicro_block_reader.cpp
@@ -189,7 +189,7 @@ int ObIMicroBlockReader::filter_white_filter(
       case sql::WHITE_OP_IN: {
         bool is_existed = false;
         if (OB_FAIL(filter.exist_in_obj_set(obj, is_existed))) {
-          LOG_WARN("Failed to check object in hashset", K(ret), K(obj));
+          LOG_WARN("Failed to check object in obj set", K(ret), K(obj));
         } else if (is_existed) {
           filtered = false;
         }

--- a/src/storage/blocksstable/ob_micro_block_reader.cpp
+++ b/src/storage/blocksstable/ob_micro_block_reader.cpp
@@ -543,7 +543,7 @@ int ObMicroBlockReader::get_multi_version_info(
 int ObMicroBlockReader::filter_pushdown_filter(
     const sql::ObPushdownFilterExecutor *parent,
     sql::ObPushdownFilterExecutor &filter,
-    const storage::PushdownFilterInfo &pd_filter_info,
+    const sql::PushdownFilterInfo &pd_filter_info,
     common::ObBitmap &result_bitmap)
 {
   int ret = OB_SUCCESS;

--- a/src/storage/blocksstable/ob_micro_block_reader.h
+++ b/src/storage/blocksstable/ob_micro_block_reader.h
@@ -23,7 +23,6 @@ namespace oceanbase
 using namespace common;
 using namespace storage;
 namespace storage {
-struct PushdownFilterInfo;
 class ObAggCell;
 }
 namespace blocksstable
@@ -88,7 +87,7 @@ public:
   int filter_pushdown_filter(
       const sql::ObPushdownFilterExecutor *parent,
       sql::ObPushdownFilterExecutor &filter,
-      const storage::PushdownFilterInfo &pd_filter_info,
+      const sql::PushdownFilterInfo &pd_filter_info,
       common::ObBitmap &result_bitmap);
   int get_rows(
     const common::ObIArray<int32_t> &cols_projector,

--- a/src/storage/blocksstable/ob_micro_block_row_scanner.cpp
+++ b/src/storage/blocksstable/ob_micro_block_row_scanner.cpp
@@ -494,7 +494,7 @@ int ObIMicroBlockRowScanner::locate_range_pos(
 int ObIMicroBlockRowScanner::filter_pushdown_filter(
     sql::ObPushdownFilterExecutor *parent,
     sql::ObPushdownFilterExecutor *filter,
-    storage::PushdownFilterInfo &pd_filter_info,
+    sql::PushdownFilterInfo &pd_filter_info,
     common::ObBitmap &bitmap)
 {
   int ret = OB_SUCCESS;

--- a/src/storage/blocksstable/ob_micro_block_row_scanner.h
+++ b/src/storage/blocksstable/ob_micro_block_row_scanner.h
@@ -26,7 +26,6 @@ namespace storage
 {
 struct ObTableIterParam;
 struct ObTableAccessContext;
-struct PushdownFilterInfo;
 class ObBlockRowStore;
 class ObTableStoreStat;
 }
@@ -62,7 +61,7 @@ public:
   int filter_pushdown_filter(
       sql::ObPushdownFilterExecutor *parent,
       sql::ObPushdownFilterExecutor *filter,
-      storage::PushdownFilterInfo &filter_info,
+      sql::PushdownFilterInfo &filter_info,
       common::ObBitmap &bitmap);
 
 protected:


### PR DESCRIPTION
<!--
Thank you for contributing to **OceanBase**! 
Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filling this PR.

**If this pull request have a significant impact, please make sure you have discussed with OceanBase group.**
-->

### Task Description
<!--
The problem you resolved by this pull request.
You can link the issue via the "close #xxx" or "ref #xxx".
-->
ref #1491 

### Solution Description
<!-- Please clearly and consice descipt the solution. -->
Add/Update white filter 'in' functions for RAW/DICT/RLE/CONST/INTEGER_BASE_DIFF decoders.

Basic process:
- **RAW**: 
  1. batch decode
  2. traverse all rows, apply filter and set result_bitmap
- **DICT**:
  1. apply filter in dict, set `ref_bitset`
  2. traverse all refs, set `result_bitmap` by using `ref_bitset`
- **RLE**:
  1. apply filter in dict, set `ref_bitset`
  2. traverse all refs, set `result_bitmap` by using `ref_bitset`
- **CONST**:
  1. if const value in filter `params` (i.e. right arguments of expr 'in'), flip over `result_bitmap`
  2. apply filter in dict, set `ref_bitset` . It needs to be combined with whether the const value is in the params.
  3. traverse all refs, set `result_bitmap` by using `ref_bitset`
- **INTEGER_BASE_DIFF**:
  1. batch decode
  2. if `max(params) < base_value` , set `result_bitmap` all false
  3. else traverse all rows, apply filter and set `result_bitmap`

### Passed Regressions
<!-- Unittest, mysql test or test it manually? -->
#### Unittest
Passed related  unittests:
1. unittest/storage/blocksstable/encoding/**test_general_column_decoder**
2. unittest/storage/blocksstable/encoding/**test_raw_decoder**
3. unittest/storage/blocksstable/encoding/**test_const_decoder**

#### Mysql test
##### Load data
**Number of data:**
1,000,000 rows.

**Data types:**
> Five tables were created for testing based on five different encoding types. 

The data types included in each table are shown in the table below:
  | bigint | int | char | varchar | decimal | ubigint | uint
-- | -- | -- | -- | -- | -- | -- | --
RAW | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
DICT | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
RLE | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
CONST | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅
INT_BASE_DIFF | ✅ | ✅ |   |   |   | ✅ | ✅

**Data organization format:**
> The data for each encoding is generated by a Python script through pseudorandom calculations based on different seeds. And we will do manual ***major freeze*** to make columns encoded.

In order to form the corresponding encoding, the data is arranged according to the following rules:

RAW: Completely random, values within each column are mostly different.
A | D | R | X | Y | Q | ... | L | T | H
-- | -- | -- | -- | -- | -- | -- | -- | -- | --

DICT: Values within the dictionary appear **randomly**. eg: the dictionary contains values {A, B, C}.
B | A | A | C | B | A | ... | C | A | B
-- | -- | -- | -- | -- | -- | -- | -- | -- | --

RLE: Values within the dictionary appear **consecutively in order**. eg: the dictionary contains values {A, B, C}.
A | A | A | A | B | B | ... | B | C | C
-- | -- | -- | -- | -- | -- | -- | -- | -- | --

CONST: 99.9% the default value ***C*** appearing, and a 0.1% probability of values {A, B} within the dictionary appearing.
C | C | C | A | C | C | ... | C | B | C
-- | -- | -- | -- | -- | -- | -- | -- | -- | --

INTEGER_BASE_DIFF: Random data appears within a certain range, and the minimum value within the data is taken as the base value B.
B+v1 | B+v2 | B | B+v3 | B+v4 | B+v5 | ... | B+vn-2 | B+vn-1 | B+vn
-- | -- | -- | -- | -- | -- | -- | -- | -- | --

##### Run
**Pattern of SQL statements used for testing:**
```mysql
select count(col_name) from table_name where col_name in (params);
```
In the code above, `col_name` is the column name, `table_name` is the table name, and `params` is the parameter list for IN, containing `params.size()` parameters that need to be matched.


**Variables in the test:**
1. Scenario:
> `T` for values in column (RAW / INTEGER_BASE_DIFF)
`F` for values not in column
`D` for values in dict table (DICT / RLE / CONST)
`C` for const value (CONST)
`n` for number of IN params

  - RAW / INTEGER_BASE_DIFF: 
    - NO: `IN (F * n)`
    - PART: `IN (T * 0.5n, F * 0.5n)`
  - DICT / RLE:
    - NO: `IN (F * n)`
    - PART: `IN (D * k, F * (n-k))`, where `k`=`min(n/2, len(dict)/2)`
  - CONST
    - NO: `IN (F * n)`
    - PART: `IN (D * k, F * (n-k))`, where `k`=`min(n/2, len(dict)/2)`
    - PART_CONST_IN: `IN (C, F * (n-1))`
2. Number of IN parameters: 
  `4 / 40 / 400`

##### Result
**Meaning of values:**
The values in the table below represent the execution time of SQL queries on the ***master branch*** divided by the execution time of the same queries on the ***issue branch*** (i.e. The **speedup ratio** of the issue branch compared to the master branch).

**Performance test results:**
> **Notice:** The following results are obtained by fully utilizing the cache for hot queries and are averaged over 3 repetitions with discarding the first round result.

RAW:
Scenario | num of IN (*) | bigint | int | char(20) | varchar(40) | decimal(11,3) | ubigint | uint
-- | -- | -- | -- | -- | -- | -- | -- | --
NO | 4 | 1.088 | 1.094 | 1.032 | 1.815 | 1.193 | 1.091 | 1.108
PART | 4 | 1.080 | 1.076 | 1.016 | 1.424 | 1.192 | 1.117 | 1.117
NO | 40 | 1.044 | 1.018 | 1.003 | 1.002 | 1.141 | 1.063 | 1.065
PART | 40 | 1.032 | 1.009 | 1.004 | 1.002 | 1.132 | 1.085 | 1.085
NO | 400 | 1.082 | 1.059 | 1.010 | 1.005 | 1.217 | 1.090 | 1.104
PART | 400 | 1.057 | 1.069 | 1.001 | 1.019 | 1.198 | 1.102 | 1.104

DICT:
Scenario | num of IN (*) | bigint | int | char(20) | varchar(40) | decimal(11,3) | ubigint | uint
-- | -- | -- | -- | -- | -- | -- | -- | --
NO | 4 | 47.600 | 53.400 | 119.545 | 167.273 | 50.545 | 45.100 | 49.200
PART | 4 | 4.560 | 4.729 | 13.894 | 19.364 | 5.325 | 4.185 | 4.603
NO | 40 | 51.600 | 57.500 | 129.600 | 165.917 | 56.091 | 49.400 | 54.000
PART | 40 | 3.988 | 3.747 | 12.847 | 18.720 | 4.412 | 3.863 | 3.852
NO | 400 | 48.100 | 54.500 | 111.909 | 117.313 | 53.091 | 49.700 | 53.100
PART | 400 | 3.868 | 3.656 | 12.530 | 18.133 | 4.558 | 4.013 | 3.779

RLE:
Scenario | num of IN (*) | bigint | int | char(20) | varchar(40) | decimal(11,3) | ubigint | uint
-- | -- | -- | -- | -- | -- | -- | -- | --
NO | 4 | 45.200 | 50.700 | 112.182 | 126.286 | 53.500 | 44.900 | 49.000
PART | 4 | 10.894 | 9.814 | 32.909 | 45.240 | 12.000 | 10.646 | 9.839
NO | 40 | 50.900 | 53.700 | 112.182 | 158.083 | 61.000 | 49.600 | 53.900
PART | 40 | 7.695 | 6.116 | 24.667 | 32.989 | 8.239 | 7.512 | 6.299
NO | 400 | 47.700 | 51.900 | 101.667 | 140.769 | 50.273 | 49.200 | 52.100
PART | 400 | 7.226 | 6.035 | 24.053 | 32.523 | 8.261 | 7.506 | 6.490

CONST:
Scenario | num of IN (*) | bigint | int | char(20) | varchar(40) | decimal(11,3) | ubigint | uint
-- | -- | -- | -- | -- | -- | -- | -- | --
NO | 4 | 44.400 | 49.300 | 149.100 | 245.100 | 51.500 | 44.800 | 48.600
PART | 4 | 23.789 | 26.474 | 56.700 | 132.905 | 27.474 | 23.947 | 25.947
PART_CONST_IN | 4 | 4.936 | 4.136 | 19.353 | 39.299 | 5.490 | 4.964 | 4.240
NO | 40 | 53.900 | 49.000 | 102.273 | 234.833 | 53.800 | 44.500 | 48.600
PART | 40 | 24.955 | 23.905 | 49.348 | 113.040 | 24.227 | 20.773 | 23.619
PART_CONST_IN | 40 | 5.465 | 4.137 | 19.697 | 41.162 | 5.644 | 4.979 | 4.208
NO | 400 | 44.400 | 49.400 | 139.000 | 203.750 | 52.500 | 52.700 | 57.600
PART | 400 | 20.455 | 22.818 | 61.040 | 99.160 | 24.545 | 24.273 | 26.545
PART_CONST_IN | 400 | 4.971 | 4.052 | 22.059 | 38.236 | 5.732 | 5.554 | 4.663

INTEGER_BASE_DIFF:
Scenario | num of IN (*) | bigint | int | ubigint | uint
-- | -- | -- | -- | -- | --
NO | 4 | 37.833 | 37.333 | 38.167 | 37.750
PART | 4 | 1.160 | 1.195 | 1.139 | 1.177
NO | 40 | 44.500 | 49.273 | 45.083 | 49.000
PART | 40 | 1.088 | 1.074 | 1.091 | 1.104
NO | 400 | 24.238 | 42.417 | 41.750 | 46.364
PART | 400 | 1.130 | 1.112 | 1.130 | 1.138

### Other Information
<!-- Any information helping to review this pull request. -->
Result csv files:
[result-issue.csv](https://github.com/oceanbase/oceanbase/files/12408585/result-issue.csv)
[result-master.csv](https://github.com/oceanbase/oceanbase/files/12408586/result-master.csv)
